### PR TITLE
Fail in case API version was not detected

### DIFF
--- a/cf-applist.sh
+++ b/cf-applist.sh
@@ -186,8 +186,14 @@ get_json () {
     is_api_v2=false
     is_api_v3=false
 
-    [[ ${next_url#/v2} != $next_url ]] && is_api_v2=true
-    [[ ${next_url#/v3} != $next_url ]] && is_api_v3=true
+    if [[ ${next_url#/v2} != $next_url ]]; then
+      is_api_v2=true
+    elif [[ ${next_url#/v3} != $next_url ]]; then
+      is_api_v3=true
+    else
+      echo "ERROR: Unable to detect API version for URI '$next_url'" >&2
+      exit 1
+    fi
 
     next_url_hash=$(echo "$next_url" "$cf_target" | $(which md5sum || which md5) | cut -d' ' -f1)
     cache_filename="/tmp/.$script_name.$user_id.$next_url_hash"

--- a/cf-curl.sh
+++ b/cf-curl.sh
@@ -91,8 +91,14 @@ get_json () {
     is_api_v2=false
     is_api_v3=false
 
-    [[ ${next_url#/v2} != $next_url ]] && is_api_v2=true
-    [[ ${next_url#/v3} != $next_url ]] && is_api_v3=true
+    if [[ ${next_url#/v2} != $next_url ]]; then
+      is_api_v2=true
+    elif [[ ${next_url#/v3} != $next_url ]]; then
+      is_api_v3=true
+    else
+      echo "ERROR: Unable to detect API version for URI '$next_url'" >&2
+      exit 1
+    fi
 
     next_url_hash=$(echo "$next_url" "$cf_target" | $(which md5sum || which md5) | cut -d' ' -f1)
     cache_filename="/tmp/.$script_name.$user_id.$next_url_hash.$RESOURCES_HASH"

--- a/cf-orglist.sh
+++ b/cf-orglist.sh
@@ -186,8 +186,14 @@ get_json () {
     is_api_v2=false
     is_api_v3=false
 
-    [[ ${next_url#/v2} != $next_url ]] && is_api_v2=true
-    [[ ${next_url#/v3} != $next_url ]] && is_api_v3=true
+    if [[ ${next_url#/v2} != $next_url ]]; then
+      is_api_v2=true
+    elif [[ ${next_url#/v3} != $next_url ]]; then
+      is_api_v3=true
+    else
+      echo "ERROR: Unable to detect API version for URI '$next_url'" >&2
+      exit 1
+    fi
 
     next_url_hash=$(echo "$next_url" "$cf_target" | $(which md5sum || which md5) | cut -d' ' -f1)
     cache_filename="/tmp/.$script_name.$user_id.$next_url_hash"

--- a/cf-routelist.sh
+++ b/cf-routelist.sh
@@ -186,8 +186,14 @@ get_json () {
     is_api_v2=false
     is_api_v3=false
 
-    [[ ${next_url#/v2} != $next_url ]] && is_api_v2=true
-    [[ ${next_url#/v3} != $next_url ]] && is_api_v3=true
+    if [[ ${next_url#/v2} != $next_url ]]; then
+      is_api_v2=true
+    elif [[ ${next_url#/v3} != $next_url ]]; then
+      is_api_v3=true
+    else
+      echo "ERROR: Unable to detect API version for URI '$next_url'" >&2
+      exit 1
+    fi
 
     next_url_hash=$(echo "$next_url" "$cf_target" | $(which md5sum || which md5) | cut -d' ' -f1)
     cache_filename="/tmp/.$script_name.$user_id.$next_url_hash"

--- a/cf-routemappings.sh
+++ b/cf-routemappings.sh
@@ -186,8 +186,14 @@ get_json () {
     is_api_v2=false
     is_api_v3=false
 
-    [[ ${next_url#/v2} != $next_url ]] && is_api_v2=true
-    [[ ${next_url#/v3} != $next_url ]] && is_api_v3=true
+    if [[ ${next_url#/v2} != $next_url ]]; then
+      is_api_v2=true
+    elif [[ ${next_url#/v3} != $next_url ]]; then
+      is_api_v3=true
+    else
+      echo "ERROR: Unable to detect API version for URI '$next_url'" >&2
+      exit 1
+    fi
 
     next_url_hash=$(echo "$next_url" "$cf_target" | $(which md5sum || which md5) | cut -d' ' -f1)
     cache_filename="/tmp/.$script_name.$user_id.$next_url_hash"


### PR DESCRIPTION
If you will try to e.g. `cf-curl.sh v2/apps` where URL starts not from slash you will be in infinite loop.
This fix help to avoid it.